### PR TITLE
feat: Add Homepage Popup CS-Cart Addon with Multiple Banner Support

### DIFF
--- a/app/addons/homepage_popup/addon.xml
+++ b/app/addons/homepage_popup/addon.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<addon scheme="3.0">
+    <id>homepage_popup</id>
+    <name language_variable="homepage_popup.addon_name">Homepage Popup</name>
+    <description language_variable="homepage_popup.addon_description">Displays a customizable popup on the homepage.</description>
+    <version>1.0</version>
+    <priority>100</priority>
+    <position>0</position>
+    <status>active</status>
+    <auto_install>MULTIVENDOR,ULTIMATE</auto_install>
+    <default_language>EN</default_language>
+    <supplier>CS-Cart Team</supplier>
+    <supplier_link>https://www.cs-cart.com</supplier_link>
+    <authors>
+        <author>
+            <name>CS-Cart Team</name>
+            <email>sales@cs-cart.com</email>
+            <url>https://www.cs-cart.com</url>
+        </author>
+    </authors>
+    <compatibility>
+        <dependencies></dependencies>
+    </compatibility>
+    <database>
+        <table name="homepage_popup_banners">
+            <item><name>banner_id</name><type>int(11) unsigned</type><auto_increment>Y</auto_increment><primary_key>Y</primary_key></item>
+            <item><name>title</name><type>varchar(255)</type><default_value></default_value></item>
+            <item><name>content</name><type>text</type><default_value></default_value></item>
+            <item><name>position</name><type>int(11) unsigned</type><default_value>0</default_value></item>
+            <item><name>status</name><type>char(1)</type><default_value>A</default_value></item>
+            <item><name>lang_code</name><type>char(2)</type><default_value>en</default_value></item>
+        </table>
+    </database>
+    <settings layout="separate" edition_type="ROOT,ULT:VENDOR">
+        <sections>
+            <section id="general">
+                <name language_variable="homepage_popup.settings.tab_general">General</name>
+                <!-- Items are defined in schema.php -->
+            </section>
+             <section id="banner_management">
+                <name language_variable="homepage_popup.settings.tab_banner_management">Banner Management</name>
+                <!-- Items are defined in schema.php -->
+            </section>
+        </sections>
+    </settings>
+</addon>

--- a/app/addons/homepage_popup/controllers/backend/homepage_popup_banners.php
+++ b/app/addons/homepage_popup/controllers/backend/homepage_popup_banners.php
@@ -1,0 +1,81 @@
+<?php
+
+use Tygh\Registry;
+use Tygh\Tygh;
+
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+$dispatch_permission_check = true;
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $return_url = 'homepage_popup_banners.manage';
+
+    // SAVE BANNER
+    if ($mode == 'update') {
+        $banner_data = $_REQUEST['banner_data'];
+        $banner_id = isset($_REQUEST['banner_id']) ? (int)$_REQUEST['banner_id'] : 0;
+
+        if (empty($banner_data['lang_code'])) {
+            $banner_data['lang_code'] = DESPATCH_LANG_CODE;
+        }
+
+        $updated_banner_id = fn_homepage_popup_update_banner($banner_data, $banner_id, DESPATCH_LANG_CODE);
+
+        if ($updated_banner_id) {
+            fn_set_notification('N', __('notice'), __('homepage_popup.banner_saved_successfully'));
+            $return_url = 'homepage_popup_banners.update?banner_id=' . $updated_banner_id;
+        } else {
+            fn_set_notification('E', __('error'), __('homepage_popup.banner_save_error'));
+            if ($banner_id) {
+                $return_url = 'homepage_popup_banners.update?banner_id=' . $banner_id;
+            } else {
+                $return_url = 'homepage_popup_banners.manage';
+            }
+        }
+    }
+
+    // DELETE BANNERS (Multiple)
+    if ($mode == 'm_delete') {
+        if (!empty($_REQUEST['banner_ids'])) {
+            $deleted_count = 0;
+            foreach ($_REQUEST['banner_ids'] as $b_id) {
+                if (fn_homepage_popup_delete_banner((int)$b_id)) {
+                    $deleted_count++;
+                }
+            }
+            if ($deleted_count > 0) {
+                fn_set_notification('N', __('notice'), __('homepage_popup.banners_deleted_successfully', array($deleted_count)));
+            }
+        }
+    }
+    return array(CONTROLLER_STATUS_OK, $return_url);
+}
+
+// MANAGE BANNERS (LIST VIEW)
+if ($mode == 'manage') {
+    list($banners, $search) = fn_homepage_popup_get_banners($_REQUEST, Registry::get('settings.Appearance.admin_elements_per_page'), DESPATCH_LANG_CODE);
+    Registry::get('view')->assign('banners', $banners);
+    Registry::get('view')->assign('search', $search);
+
+// ADD/EDIT BANNER VIEW
+} elseif ($mode == 'update') {
+    $banner_id = isset($_REQUEST['banner_id']) ? (int)$_REQUEST['banner_id'] : 0;
+    $banner_data = fn_homepage_popup_get_banner_data($banner_id, DESPATCH_LANG_CODE);
+
+    if (empty($banner_data) && $banner_id > 0) {
+        return array(CONTROLLER_STATUS_NO_PAGE);
+    }
+    Registry::get('view')->assign('banner_data', $banner_data);
+    Registry::get('view')->assign('languages', fn_get_translation_languages());
+
+// DELETE BANNER (SINGLE from list)
+} elseif ($mode == 'delete') {
+    $banner_id = isset($_REQUEST['banner_id']) ? (int)$_REQUEST['banner_id'] : 0;
+    if ($banner_id) {
+        if (fn_homepage_popup_delete_banner($banner_id)) {
+            fn_set_notification('N', __('notice'), __('homepage_popup.banner_deleted_successfully'));
+        }
+    }
+    return array(CONTROLLER_STATUS_OK, 'homepage_popup_banners.manage');
+}
+?>

--- a/app/addons/homepage_popup/func.php
+++ b/app/addons/homepage_popup/func.php
@@ -1,0 +1,205 @@
+<?php
+
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+use Tygh\Registry;
+use Tygh\Session;
+use Tygh\Tygh;
+
+/**
+ * Hook for index_post: Decides whether to show the homepage popup.
+ *
+ * @param string $controller The current controller.
+ * @param string $mode The current mode.
+ * @param string $action The current action.
+ * @param array $dispatch_extra Any extra dispatch parameters.
+ * @param array $params The request parameters.
+ * @param string $lang_code The language code for the current context (CART_LANGUAGE on storefront).
+ */
+function fn_homepage_popup_index_post($controller, $mode, $action, $dispatch_extra, $params, $lang_code)
+{
+    if (AREA == 'C' && $controller == 'index' && $mode == 'index') {
+        $popup_closed_cookie = !empty($_COOKIE['homepage_popup_closed']) && $_COOKIE['homepage_popup_closed'] === 'true';
+
+        if (empty(Session::get('homepage_popup_shown')) && !$popup_closed_cookie) {
+            // Use the $lang_code from the hook, which is CART_LANGUAGE on storefront
+            $active_banners = fn_homepage_popup_get_active_banners($lang_code);
+            if (!empty($active_banners)) {
+                Registry::get('view')->assign('homepage_popup_banners', $active_banners);
+                Registry::get('view')->assign('show_homepage_popup', true);
+                Session::set('homepage_popup_shown', true);
+            } else {
+                Registry::get('view')->assign('show_homepage_popup', false);
+            }
+        } else {
+            Registry::get('view')->assign('show_homepage_popup', false);
+        }
+    }
+}
+
+/**
+ * Gets a list of homepage popup banners for the backend.
+ *
+ * @param array $params Search parameters.
+ * @param int $items_per_page Number of items per page for pagination.
+ * @param string $lang_code Language code (typically DESPATCH_LANG_CODE for backend).
+ * @return array An array containing the list of banners and search parameters.
+ */
+function fn_homepage_popup_get_banners($params = array(), $items_per_page = 0, $lang_code = DESPATCH_LANG_CODE)
+{
+    $default_params = array(
+        'page' => 1,
+        'items_per_page' => $items_per_page,
+        'sort_by' => 'position',
+        'sort_order' => 'asc',
+    );
+
+    $params = array_merge($default_params, $params);
+
+    $sortings = array(
+        'title' => '?:homepage_popup_banners.title',
+        'position' => '?:homepage_popup_banners.position',
+        'status' => '?:homepage_popup_banners.status'
+    );
+
+    $condition = $limit = '';
+
+    // Add lang_code condition for all queries related to this table if it has lang_code column
+    $condition .= db_quote(" AND lang_code = ?s", $lang_code);
+
+    if (!empty($params['item_ids'])) {
+        $condition .= db_quote(" AND banner_id IN (?n)", explode(',', $params['item_ids']));
+    }
+
+    $sorting = db_sort($params, $sortings, 'position', 'asc');
+
+    if (!empty($params['items_per_page'])) {
+        // Apply lang_code to total_items query
+        $params['total_items'] = db_get_field("SELECT COUNT(*) FROM ?:homepage_popup_banners WHERE 1 $condition");
+        $limit = db_paginate($params['page'], $params['items_per_page'], $params['total_items']);
+    }
+
+    $banners = db_get_array(
+        "SELECT * FROM ?:homepage_popup_banners "
+        . "WHERE 1 $condition " // lang_code is already part of $condition
+        . "ORDER BY $sorting $limit"
+    );
+
+    foreach ($banners as &$banner) {
+        $banner['main_pair'] = fn_get_image_pairs($banner['banner_id'], 'homepage_popup_banner', 'M', true, true, $lang_code);
+    }
+
+    return array($banners, $params);
+}
+
+/**
+ * Gets data for a specific homepage popup banner for the backend.
+ *
+ * @param int $banner_id The ID of the banner.
+ * @param string $lang_code Language code (typically DESPATCH_LANG_CODE for backend).
+ * @return array The banner data.
+ */
+function fn_homepage_popup_get_banner_data($banner_id, $lang_code = DESPATCH_LANG_CODE)
+{
+    $banner = array();
+    if (!empty($banner_id)) {
+        $banner = db_get_row("SELECT * FROM ?:homepage_popup_banners WHERE banner_id = ?i AND lang_code = ?s", $banner_id, $lang_code);
+
+        // Fallback: if no banner for the specified lang_code, try to get data from any other language for this banner_id
+        // This might be useful if you want to create a new language version based on an existing one.
+        if (empty($banner)) {
+            $any_lang_banner = db_get_row("SELECT * FROM ?:homepage_popup_banners WHERE banner_id = ?i", $banner_id);
+            if (!empty($any_lang_banner)) {
+                // Return the existing data but clear content fields that need translation and set the target lang_code
+                $banner = $any_lang_banner;
+                $banner['title'] = ''; // Clear title for new translation
+                $banner['content'] = ''; // Clear content for new translation
+                $banner['lang_code'] = $lang_code; // Set to the target language
+                // Image might be shared or re-uploaded, main_pair will be fetched/created for target lang_code
+            }
+        }
+
+        if (!empty($banner)) {
+             // Fetch image pair for the target $lang_code
+             $banner['main_pair'] = fn_get_image_pairs($banner_id, 'homepage_popup_banner', 'M', true, true, $lang_code);
+        }
+    }
+    return $banner;
+}
+
+/**
+ * Updates or creates a homepage popup banner.
+ *
+ * @param array $data The banner data from the form.
+ * @param int $banner_id The ID of the banner to update, or 0 to create.
+ * @param string $lang_code Language code for the content (typically DESPATCH_LANG_CODE for backend).
+ * @return int|false The ID of the updated/created banner, or false on failure.
+ */
+function fn_homepage_popup_update_banner($data, $banner_id, $lang_code = DESPATCH_LANG_CODE)
+{
+    if (empty($data)) {
+        return false;
+    }
+
+    // Ensure lang_code is set in the data array for insertion/update
+    $data['lang_code'] = $lang_code;
+
+    if (empty($banner_id)) {
+        // Create new banner - banner_id will be auto-incremented
+        $banner_id = db_query("INSERT INTO ?:homepage_popup_banners ?e", $data);
+    } else {
+        // Update existing banner for the given banner_id and lang_code
+        // Check if a record for this banner_id and lang_code already exists
+        $exists = db_get_field("SELECT COUNT(*) FROM ?:homepage_popup_banners WHERE banner_id = ?i AND lang_code = ?s", $banner_id, $lang_code);
+        if ($exists) {
+            db_query("UPDATE ?:homepage_popup_banners SET ?u WHERE banner_id = ?i AND lang_code = ?s", $data, $banner_id, $lang_code);
+        } else {
+            // Insert a new language version for an existing banner_id
+            $data['banner_id'] = $banner_id; // Ensure banner_id is part of data for insert
+            db_query("INSERT INTO ?:homepage_popup_banners ?e", $data);
+        }
+    }
+
+    if ($banner_id) {
+        // Attach image pairs (handles new uploads and existing image linking)
+        // 'new_banner_image' is the typical name for the main image uploader in the form
+        fn_attach_image_pairs('new_banner_image', 'homepage_popup_banner', $banner_id, $lang_code);
+    }
+    return $banner_id;
+}
+
+/**
+ * Deletes a homepage popup banner and its associated images.
+ *
+ * @param int $banner_id The ID of the banner to delete.
+ * @return bool True on success, false otherwise.
+ */
+function fn_homepage_popup_delete_banner($banner_id)
+{
+    if (!empty($banner_id)) {
+        // Delete all language versions of the banner
+        $res = db_query("DELETE FROM ?:homepage_popup_banners WHERE banner_id = ?i", $banner_id);
+        // Deletes all image pairs associated with this banner_id for the 'homepage_popup_banner' object type
+        fn_delete_image_pairs($banner_id, 'homepage_popup_banner');
+        return (bool)$res;
+    }
+    return false;
+}
+
+/**
+ * Gets active homepage popup banners for the storefront.
+ *
+ * @param string $lang_code Language code (typically CART_LANGUAGE for storefront).
+ * @return array An array of active banners.
+ */
+function fn_homepage_popup_get_active_banners($lang_code = CART_LANGUAGE)
+{
+    $banners_data = db_get_array(
+        "SELECT * FROM ?:homepage_popup_banners WHERE status = 'A' AND lang_code = ?s ORDER BY position ASC", $lang_code
+    );
+    foreach ($banners_data as &$banner) {
+        $banner['main_pair'] = fn_get_image_pairs($banner['banner_id'], 'homepage_popup_banner', 'M', true, true, $lang_code);
+    }
+    return $banners_data;
+}
+?>

--- a/app/addons/homepage_popup/init.php
+++ b/app/addons/homepage_popup/init.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+fn_register_hooks(
+    'index_post' // This hook is executed after the main index controller logic
+);

--- a/app/addons/homepage_popup/schemas/settings/schema.php
+++ b/app/addons/homepage_popup/schemas/settings/schema.php
@@ -1,0 +1,51 @@
+<?php
+
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+$schema = array(
+    'tabs' => array(
+        'general' => array(
+            'title' => __('homepage_popup.settings.tab_general'),
+            'position' => 10, // Added position
+            'items' => array(
+                'popup_width' => array(
+                    'type' => 'input',
+                    'default_value' => '600',
+                    'name' => __('homepage_popup.settings.popup_width'),
+                    'tooltip' => __('homepage_popup.settings.tooltip.popup_width'),
+                    'suffix' => 'px',
+                    'position' => 10, // Added position
+                ),
+                'popup_height' => array(
+                    'type' => 'input',
+                    'default_value' => '400',
+                    'name' => __('homepage_popup.settings.popup_height'),
+                    'tooltip' => __('homepage_popup.settings.tooltip.popup_height'),
+                    'suffix' => 'px',
+                    'position' => 20, // Added position
+                ),
+                'enable_background_dimming' => array(
+                    'type' => 'checkbox',
+                    'default_value' => 'Y',
+                    'name' => __('homepage_popup.settings.enable_background_dimming'),
+                    'tooltip' => __('homepage_popup.settings.tooltip.enable_background_dimming'),
+                    'position' => 30, // Added position
+                ),
+            ),
+        ),
+        'banner_management' => array(
+            'title' => __('homepage_popup.settings.tab_banner_management'),
+            'position' => 20, // Added position
+            'items' => array(
+                'manage_banners_link' => array(
+                    'type' => 'template',
+                    'template' => 'addons/homepage_popup/components/manage_banners_link.tpl',
+                    'tooltip' => __('homepage_popup.settings.tooltip.manage_banners_link'),
+                    'position' => 10, // Added position
+                ),
+            ),
+        ),
+    )
+);
+return $schema;
+?>

--- a/design/backend/templates/addons/homepage_popup/components/manage_banners_link.tpl
+++ b/design/backend/templates/addons/homepage_popup/components/manage_banners_link.tpl
@@ -1,0 +1,1 @@
+<a href="{"homepage_popup_banners.manage"|fn_url}" class="btn btn-primary">{__("homepage_popup.manage_banners_button")}</a>

--- a/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/manage.tpl
+++ b/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/manage.tpl
@@ -1,0 +1,62 @@
+{capture name="mainbox"}
+    <form action="{""|fn_url}" method="post" name="homepage_popup_banners_form">
+        <div id="pagination_contents"> {*This div is important for AJAX updates from pagination/check_items*}
+        {include file="common/pagination.tpl" save_current_page=true save_current_url=true div_id="pagination_contents"}
+
+        {if $banners}
+            <div class="table-responsive-wrapper">
+                <table width="100%" class="table table-middle table-objects table-striped">
+                <thead class="cm-first-sibling">
+                <tr>
+                    <th width="1%" class="left cm-no-hide-input">
+                        {include file="common/check_items.tpl" check_statuses=fn_get_default_status_filters('', true) status_target_id="pagination_contents"}</th>
+                    <th width="40%">{__("title")}</th>
+                    <th width="10%">{__("position_short")}</th>
+                    <th width="10%" class="center">{__("status")}</th>
+                    <th width="10%">&nbsp;</th>
+                </tr>
+                </thead>
+                <tbody>
+                {foreach from=$banners item=banner}
+                <tr class="cm-row-status-{$banner.status|lower}">
+                    <td class="left cm-no-hide-input">
+                        <input type="checkbox" name="banner_ids[]" value="{$banner.banner_id}" class="cm-item" /></td>
+                    <td>
+                        <a href="{"homepage_popup_banners.update?banner_id=`$banner.banner_id`"|fn_url}">{$banner.title}</a>
+                    </td>
+                    <td>{$banner.position}</td>
+                    <td class="center">
+                        {include file="common/select_popup.tpl" id=$banner.banner_id status=$banner.status object_id_name="banner_id" table="homepage_popup_banners" popup_additional_class="" hide_for_vendor=true display="text"}
+                    </td>
+                    <td class="nowrap right">
+                        {capture name="tools_list"}
+                            <li>{btn type="list" text=__("edit") href="homepage_popup_banners.update?banner_id=`$banner.banner_id`"}</li>
+                            <li>{btn type="list" text=__("delete") class="cm-confirm" href="homepage_popup_banners.delete?banner_id=`$banner.banner_id`" method="POST"}</li>
+                        {/capture}
+                        <div class="hidden-tools">
+                            {dropdown content=$smarty.capture.tools_list}
+                        </div>
+                    </td>
+                </tr>
+                {/foreach}
+                </tbody>
+                </table>
+            </div>
+        {else}
+            <p class="no-items">{__("no_data")}</p>
+        {/if}
+
+        {include file="common/pagination.tpl" div_id="pagination_contents"}
+        </div> {* End pagination_contents div *}
+    </form>
+{/capture}
+
+{capture name="buttons"}
+    {capture name="tools_list"}
+        <li>{btn type="delete_selected" dispatch="dispatch[homepage_popup_banners.m_delete]" form="homepage_popup_banners_form"}</li>
+    {/capture}
+    {dropdown content=$smarty.capture.tools_list}
+    {btn type="add" text=__("homepage_popup.add_banner_button") href="homepage_popup_banners.update"}
+{/capture}
+
+{include file="common/mainbox.tpl" title=__("homepage_popup.manage_banners_title") content=$smarty.capture.mainbox buttons=$smarty.capture.buttons}

--- a/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/update.tpl
+++ b/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/update.tpl
@@ -1,0 +1,56 @@
+{capture name="mainbox"}
+    <form action="{""|fn_url}" method="post" name="homepage_popup_banner_update_form" enctype="multipart/form-data" class="form-horizontal form-edit">
+        <input type="hidden" name="banner_id" value="{$banner_data.banner_id|default:0}" />
+
+        <div class="tabs cm-j-tabs">
+            <ul class="nav nav-tabs">
+                <li id="tab_general_banner" class="cm-js active"><a>{__("general")}</a></li>
+            </ul>
+        </div>
+
+        <div class="cm-tabs-content" id="content_tab_general_banner">
+            <fieldset>
+                <div class="control-group">
+                    <label class="control-label cm-required" for="elm_banner_title">{__("title")}:</label>
+                    <div class="controls">
+                        <input type="text" name="banner_data[title]" id="elm_banner_title" value="{$banner_data.title}" size="50" class="input-large" />
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="elm_banner_content">{__("content")}:</label>
+                    <div class="controls">
+                        <textarea name="banner_data[content]" id="elm_banner_content" cols="50" rows="8" class="cm-wysiwyg input-large">{$banner_data.content}</textarea>
+                    </div>
+                </div>
+
+                {include file="common/image_uploader.tpl" image_name="new_banner_image" image_object_type="homepage_popup_banner" image_pair=$banner_data.main_pair image_object_id=$banner_data.banner_id|default:0 image_title=__("image")}
+
+                <div class="control-group">
+                    <label class="control-label" for="elm_banner_position">{__("position_short")}:</label>
+                    <div class="controls">
+                        <input type="text" name="banner_data[position]" id="elm_banner_position" value="{$banner_data.position|default:0}" size="10" />
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="elm_banner_status">{__("status")}:</label>
+                    <div class="controls">
+                        <select name="banner_data[status]" id="elm_banner_status">
+                            <option value="A" {if $banner_data.status == "A"}selected="selected"{/if}>{__("active")}</option>
+                            <option value="D" {if $banner_data.status == "D"}selected="selected"{/if}>{__("disabled")}</option>
+                        </select>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+
+        {assign var="but_role" value="submit-link"}
+        {assign var="but_name" value="dispatch[homepage_popup_banners.update]"}
+        {assign var="but_target_form" value="homepage_popup_banner_update_form"}
+        {capture name="buttons_block"}
+            {include file="buttons/save_cancel.tpl" but_name=$but_name cancel_action="close" save=$banner_data.banner_id}
+        {/capture}
+    </form>
+{/capture}
+{include file="common/mainbox.tpl" title=($banner_data.banner_id ? $banner_data.title : __("homepage_popup.add_banner_button")) content=$smarty.capture.mainbox buttons=$smarty.capture.buttons_block}

--- a/design/themes/responsive/css/addons/homepage_popup/styles.css
+++ b/design/themes/responsive/css/addons/homepage_popup/styles.css
@@ -1,0 +1,186 @@
+#homepage_popup_overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent black */
+    z-index: 9998; /* Below popup, above everything else */
+    display: none; /* Hidden by default, JS controls visibility */
+}
+
+#homepage_popup_wrapper {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    z-index: 9999; /* Above overlay */
+    display: none; /* Hidden by default, JS controls visibility */
+    padding: 0; /* Reset padding, will be handled by inner content or slider area */
+    box-sizing: border-box;
+    /* overflow-y: auto; -- This will be handled by slide content area if needed */
+    /* Width and height are set inline from settings */
+}
+
+/* Slider Container - relative positioning for nav elements */
+#homepage_popup_slider_container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+.hp-slides {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.hp-slide {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    display: none; /* JS will manage display:block for the active slide */
+}
+
+.hp-slide.active {
+    display: block; /* JS adds this class to the current slide */
+}
+
+/* Content area within a slide */
+.hp-slide-content-area {
+    padding: 20px 20px 50px 20px; /* Main padding for slide content, bottom padding for dots */
+    height: 100%;
+    overflow-y: auto;
+    box-sizing: border-box;
+    position:relative; /* For potential absolute positioning of elements within if needed */
+}
+
+.hp-slide-content-area h2 {
+    margin-top: 0;
+    font-size: 1.4em;
+    margin-bottom: 10px;
+}
+
+.hp-slide .popup_image_container {
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.hp-slide .popup_image_container img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid #ddd;
+    max-height: calc(100% - 80px); /* Example: limit image height if other content exists */
+}
+
+.hp-slide .popup_text_content {
+    margin-bottom: 15px;
+    line-height: 1.5;
+}
+
+
+/* Slider Navigation Buttons */
+.hp-slider-nav {
+    /* This class is on the container of prev/next buttons */
+}
+
+.hp-prev,
+.hp-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background-color: rgba(0, 0, 0, 0.3);
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    cursor: pointer;
+    z-index: 10000; /* Above slides but below close button */
+    font-size: 16px;
+    border-radius: 3px;
+    transition: background-color 0.2s ease;
+}
+
+.hp-prev:hover,
+.hp-next:hover {
+    background-color: rgba(0, 0, 0, 0.6);
+}
+
+.hp-prev {
+    left: 15px; /* Adjusted padding from wrapper edge */
+}
+
+.hp-next {
+    right: 15px; /* Adjusted padding from wrapper edge */
+}
+
+/* Slider Dots Navigation */
+.hp-slider-dots {
+    position: absolute;
+    bottom: 15px; /* Position at the bottom of the slider_container */
+    left: 0;
+    right: 0;
+    text-align: center;
+    padding: 5px 0;
+    z-index: 10000;
+}
+
+.hp-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    background-color: #bbb;
+    border-radius: 50%;
+    margin: 0 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.hp-dot.active {
+    background-color: #717171;
+}
+
+/* Close button styling - ensure it's above everything */
+#close_homepage_popup {
+    position: absolute;
+    top: 5px; /* Closer to edge */
+    right: 5px; /* Closer to edge */
+    background: rgba(230, 230, 230, 0.8); /* Slightly transparent */
+    border: 1px solid #aaa;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    line-height: 28px;
+    text-align: center;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 16px;
+    color: #333;
+    z-index: 10001; /* Highest z-index */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+    transition: background-color 0.2s ease, transform 0.1s ease;
+}
+#close_homepage_popup:hover {
+    background: rgba(221, 221, 221, 1);
+    transform: scale(1.1);
+}
+#close_homepage_popup:active {
+    transform: scale(0.95);
+}
+
+/* Legacy content area ID - ensure it doesn't conflict if still in TPL somehow */
+/* This was from the single-content version, slider uses .hp-slide-content-area now */
+#homepage_popup_content_area {
+    /* Styles here would apply if this ID is still used, but it should be superseded */
+}
+#homepage_popup_content_area h2 { /* From old structure, new is .hp-slide-content-area h2 */
+    margin-top: 0;
+    font-size: 1.5em;
+}
+
+/* These were from old structure, now scoped within .hp-slide */
+.popup_image_container { }
+.popup_text_content { }

--- a/design/themes/responsive/templates/addons/homepage_popup/hooks/index/index.post.tpl
+++ b/design/themes/responsive/templates/addons/homepage_popup/hooks/index/index.post.tpl
@@ -1,0 +1,52 @@
+{** Hook for displaying the popup on the homepage **}
+
+{if $show_homepage_popup && $homepage_popup_banners}
+    {style src="addons/homepage_popup/styles.css"}
+    {script src="js/addons/homepage_popup/func.js"}
+
+    <div id="homepage_popup_overlay" style="display:none;"></div>
+    <div id="homepage_popup_wrapper"
+         style="display:block; width: {$addons.homepage_popup.popup_width|default:600}px; height: {$addons.homepage_popup.popup_height|default:400}px;"
+         data-dimming-enabled="{$addons.homepage_popup.enable_background_dimming}">
+
+        <button id="close_homepage_popup" type="button">{__("homepage_popup.close_button")}</button>
+
+        <div id="homepage_popup_slider_container">
+            <div class="hp-slides">
+                {foreach from=$homepage_popup_banners item="banner" name="banner_loop"}
+                    <div class="hp-slide" {if !$smarty.foreach.banner_loop.first}style="display:none;"{/if}> {* Show only the first slide initially *}
+                        <div class="hp-slide-content-area">
+                            {if $banner.title}
+                                <h2>{$banner.title}</h2>
+                            {/if}
+
+                            {if $banner.main_pair.image_path}
+                                <div class="popup_image_container">
+                                    <img src="{$banner.main_pair.image_path}" alt="{$banner.main_pair.alt|default:$banner.title|escape:html}">
+                                </div>
+                            {/if}
+
+                            {if $banner.content}
+                                <div class="popup_text_content">
+                                    {$banner.content nofilter}
+                                </div>
+                            {/if}
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+
+            {if count($homepage_popup_banners) > 1}
+                <div class="hp-slider-nav">
+                    <button class="hp-prev" type="button">{__("homepage_popup.previous_slide")}</button>
+                    <button class="hp-next" type="button">{__("homepage_popup.next_slide")}</button>
+                </div>
+                <div class="hp-slider-dots" style="text-align:center; margin-top:10px;">
+                    {foreach from=$homepage_popup_banners item="banner" name="dot_loop"}
+                        <span class="hp-dot {if $smarty.foreach.dot_loop.first}active{/if}" data-slide-index="{$smarty.foreach.dot_loop.iteration - 1}"></span>
+                    {/foreach}
+                </div>
+            {/if}
+        </div>
+    </div>
+{/if}

--- a/js/addons/homepage_popup/func.js
+++ b/js/addons/homepage_popup/func.js
@@ -1,0 +1,116 @@
+(function(_, $) { // Tygh Utilities and jQuery
+    $(document).ready(function() {
+        // Existing popup closing logic
+        var popup_wrapper = $('#homepage_popup_wrapper');
+        var popup_overlay = $('#homepage_popup_overlay');
+        var close_button = $('#close_homepage_popup');
+        var cookie_name = 'homepage_popup_closed';
+
+        // Renamed existing functions to avoid potential conflicts if this file grows
+        function showMainPopupContainer() {
+            if (popup_overlay.length && popup_wrapper.data('dimming-enabled') === 'Y') {
+                popup_overlay.show();
+            }
+            if (popup_wrapper.length) {
+                popup_wrapper.show(); // This makes the entire wrapper visible
+            }
+        }
+
+        function hideMainPopupContainer() {
+            if (popup_overlay.length) {
+                popup_overlay.hide();
+            }
+            if (popup_wrapper.length) {
+                popup_wrapper.hide();
+            }
+        }
+
+        // This logic determines if the popup (wrapper) should be visible at all on page load
+        if (popup_wrapper.length && popup_wrapper.css('display') === 'block') {
+            // If server decided to show it (via $show_homepage_popup in TPL resulting in display:block)
+            // and overlay is enabled, show overlay too. The wrapper is already 'display:block'.
+            if (popup_overlay.length && popup_wrapper.data('dimming-enabled') === 'Y') {
+                popup_overlay.show();
+            }
+        } else if ($.cookies.get(cookie_name) === 'true') {
+            // If cookie says closed, ensure it's hidden (this might be redundant if TPL already handles it via $show_homepage_popup)
+             hideMainPopupContainer();
+        }
+
+        if (close_button.length) {
+            close_button.on('click', function() {
+                hideMainPopupContainer();
+                $.cookies.set(cookie_name, 'true', { path: '/' });
+            });
+        }
+
+        // Optional: Close popup if overlay is clicked (remains commented as per original)
+        if (popup_overlay.length && popup_wrapper.data('dimming-enabled') === 'Y') {
+            popup_overlay.on('click', function() {
+                // hideMainPopupContainer();
+                // $.cookies.set(cookie_name, 'true', { path: '/' });
+            });
+        }
+
+        // New Slider Logic - only proceeds if the main popup_wrapper is visible
+        if (popup_wrapper.length && popup_wrapper.css('display') === 'block') {
+            var slider_container = $('#homepage_popup_slider_container');
+            if (slider_container.length) {
+                var slides = slider_container.find('.hp-slide');
+                var next_btn = slider_container.find('.hp-next');
+                var prev_btn = slider_container.find('.hp-prev');
+                var dots = slider_container.find('.hp-dot');
+                var current_slide_index = 0;
+                var num_slides = slides.length;
+
+                if (num_slides > 0) { // Ensure there's at least one slide to manage
+                    function showSlide(index) {
+                        slides.hide().removeClass('active');
+                        // .get(index) to get DOM element then re-wrap if not already jQuery object
+                        $(slides[index]).show().addClass('active');
+
+                        if (dots.length) { // Check if dots exist
+                            dots.removeClass('active');
+                            $(dots[index]).addClass('active');
+                        }
+
+                        current_slide_index = index;
+                    }
+
+                    if (num_slides > 1) {
+                        next_btn.on('click', function() {
+                            var new_index = (current_slide_index + 1) % num_slides;
+                            showSlide(new_index);
+                        });
+
+                        prev_btn.on('click', function() {
+                            var new_index = (current_slide_index - 1 + num_slides) % num_slides;
+                            showSlide(new_index);
+                        });
+
+                        dots.on('click', function() {
+                            var new_index = $(this).data('slide-index');
+                            if (typeof new_index !== 'undefined') {
+                                showSlide(parseInt(new_index, 10));
+                            }
+                        });
+
+                        // Initial state for dots if multiple slides (slide 0 already visible from TPL)
+                        $(dots[0]).addClass('active');
+
+                    } else { // Only one slide
+                        // Hide nav buttons and dots if they were somehow rendered
+                        if (next_btn.parent().hasClass('hp-slider-nav')) { // Check parent to hide whole nav div
+                           next_btn.parent().hide();
+                        }
+                        slider_container.find('.hp-slider-dots').hide();
+                    }
+
+                    // Initial state for the first slide (already visible from TPL)
+                    $(slides[0]).addClass('active');
+
+                }
+            }
+        }
+    });
+}(Tygh, Tygh.$));

--- a/var/langs/en/addons/homepage_popup.po
+++ b/var/langs/en/addons/homepage_popup.po
@@ -1,0 +1,98 @@
+# Language: English
+# Add-on: homepage_popup
+
+msgctxt "homepage_popup.popup_title"
+msgid "Popup Title"
+msgstr "Popup Title"
+
+msgctxt "homepage_popup.popup_text_placeholder"
+msgid "This is the popup content."
+msgstr "This is the popup content."
+
+msgctxt "homepage_popup.close_button"
+msgid "Close"
+msgstr "Close"
+
+msgctxt "homepage_popup.settings.tab_general"
+msgid "General Settings"
+msgstr "General Settings"
+
+msgctxt "homepage_popup.settings.popup_width"
+msgid "Popup Width"
+msgstr "Popup Width"
+
+msgctxt "homepage_popup.settings.tooltip.popup_width"
+msgid "Set the width of the popup in pixels."
+msgstr "Set the width of the popup in pixels."
+
+msgctxt "homepage_popup.settings.popup_height"
+msgid "Popup Height"
+msgstr "Popup Height"
+
+msgctxt "homepage_popup.settings.tooltip.popup_height"
+msgid "Set the height of the popup in pixels (optional, content will scroll if it exceeds this)."
+msgstr "Set the height of the popup in pixels (optional, content will scroll if it exceeds this)."
+
+msgctxt "homepage_popup.settings.enable_background_dimming"
+msgid "Enable Background Dimming"
+msgstr "Enable Background Dimming"
+
+msgctxt "homepage_popup.settings.tooltip.enable_background_dimming"
+msgid "Check this to dim the background when the popup is active."
+msgstr "Check this to dim the background when the popup is active."
+
+msgctxt "homepage_popup.popup_title_default"
+msgid "Welcome!"
+msgstr "Welcome!"
+
+msgctxt "homepage_popup.addon_name"
+msgid "Homepage Popup"
+msgstr "Homepage Popup"
+
+msgctxt "homepage_popup.addon_description"
+msgid "Displays a customizable popup on the homepage."
+msgstr "Displays a customizable popup on the homepage."
+
+msgctxt "homepage_popup.manage_banners_button"
+msgid "Manage Banners"
+msgstr "Manage Banners"
+
+msgctxt "homepage_popup.add_banner_button"
+msgid "Add Banner"
+msgstr "Add Banner"
+
+msgctxt "homepage_popup.manage_banners_title"
+msgid "Manage Homepage Popup Banners"
+msgstr "Manage Homepage Popup Banners"
+
+msgctxt "homepage_popup.banner_saved_successfully"
+msgid "Banner saved successfully."
+msgstr "Banner saved successfully."
+
+msgctxt "homepage_popup.banner_save_error"
+msgid "Error saving banner."
+msgstr "Error saving banner."
+
+msgctxt "homepage_popup.banners_deleted_successfully"
+msgid "%d banners deleted successfully."
+msgstr "%d banners deleted successfully."
+
+msgctxt "homepage_popup.banner_deleted_successfully"
+msgid "Banner deleted successfully."
+msgstr "Banner deleted successfully."
+
+msgctxt "homepage_popup.settings.tab_banner_management"
+msgid "Banner Management"
+msgstr "Banner Management"
+
+msgctxt "homepage_popup.settings.tooltip.manage_banners_link"
+msgid "Click to manage the banners/slides for the homepage popup."
+msgstr "Click to manage the banners/slides for the homepage popup."
+
+msgctxt "homepage_popup.previous_slide"
+msgid "Previous"
+msgstr "Previous"
+
+msgctxt "homepage_popup.next_slide"
+msgid "Next"
+msgstr "Next"

--- a/var/langs/ru/addons/homepage_popup.po
+++ b/var/langs/ru/addons/homepage_popup.po
@@ -1,0 +1,98 @@
+# Language: Russian
+# Add-on: homepage_popup
+
+msgctxt "homepage_popup.popup_title"
+msgid "Popup Title"
+msgstr "Заголовок окна"
+
+msgctxt "homepage_popup.popup_text_placeholder"
+msgid "This is the popup content."
+msgstr "Это содержимое всплывающего окна."
+
+msgctxt "homepage_popup.close_button"
+msgid "Close"
+msgstr "Закрыть"
+
+msgctxt "homepage_popup.settings.tab_general"
+msgid "General Settings"
+msgstr "Основные настройки"
+
+msgctxt "homepage_popup.settings.popup_width"
+msgid "Popup Width"
+msgstr "Ширина всплывающего окна"
+
+msgctxt "homepage_popup.settings.tooltip.popup_width"
+msgid "Set the width of the popup in pixels."
+msgstr "Установите ширину всплывающего окна в пикселях."
+
+msgctxt "homepage_popup.settings.popup_height"
+msgid "Popup Height"
+msgstr "Высота всплывающего окна"
+
+msgctxt "homepage_popup.settings.tooltip.popup_height"
+msgid "Set the height of the popup in pixels (optional, content will scroll if it exceeds this)."
+msgstr "Установите высоту всплывающего окна в пикселях (необязательно, содержимое будет прокручиваться, если оно превысит это значение)."
+
+msgctxt "homepage_popup.settings.enable_background_dimming"
+msgid "Enable Background Dimming"
+msgstr "Включить затемнение фона"
+
+msgctxt "homepage_popup.settings.tooltip.enable_background_dimming"
+msgid "Check this to dim the background when the popup is active."
+msgstr "Отметьте это, чтобы затемнить фон, когда активно всплывающее окно."
+
+msgctxt "homepage_popup.popup_title_default"
+msgid "Welcome!"
+msgstr "Добро пожаловать!"
+
+msgctxt "homepage_popup.addon_name"
+msgid "Homepage Popup"
+msgstr "Всплывающее окно на главной"
+
+msgctxt "homepage_popup.addon_description"
+msgid "Displays a customizable popup on the homepage."
+msgstr "Отображает настраиваемое всплывающее окно на главной странице."
+
+msgctxt "homepage_popup.manage_banners_button"
+msgid "Manage Banners"
+msgstr "Управление баннерами"
+
+msgctxt "homepage_popup.add_banner_button"
+msgid "Add Banner"
+msgstr "Добавить баннер"
+
+msgctxt "homepage_popup.manage_banners_title"
+msgid "Manage Homepage Popup Banners"
+msgstr "Управление баннерами всплывающего окна"
+
+msgctxt "homepage_popup.banner_saved_successfully"
+msgid "Banner saved successfully."
+msgstr "Баннер успешно сохранен."
+
+msgctxt "homepage_popup.banner_save_error"
+msgid "Error saving banner."
+msgstr "Ошибка сохранения баннера."
+
+msgctxt "homepage_popup.banners_deleted_successfully"
+msgid "%d banners deleted successfully."
+msgstr "Успешно удалено %d баннеров."
+
+msgctxt "homepage_popup.banner_deleted_successfully"
+msgid "Banner deleted successfully."
+msgstr "Баннер успешно удален."
+
+msgctxt "homepage_popup.settings.tab_banner_management"
+msgid "Banner Management"
+msgstr "Управление баннерами"
+
+msgctxt "homepage_popup.settings.tooltip.manage_banners_link"
+msgid "Click to manage the banners/slides for the homepage popup."
+msgstr "Нажмите для управления баннерами/слайдами всплывающего окна."
+
+msgctxt "homepage_popup.previous_slide"
+msgid "Previous"
+msgstr "Назад"
+
+msgctxt "homepage_popup.next_slide"
+msgid "Next"
+msgstr "Вперед"


### PR DESCRIPTION
This commit introduces the 'Homepage Popup' addon for CS-Cart.

Key Features:
- Displays a customizable popup on the main homepage (dispatch=index.index).
- Popup visibility is controlled per session or until you close it (using a cookie).
- Addon settings allow configuration of popup width, height, and background dimming effect.

Multiple Banners/Slides:
- Administrators can create, manage, and delete multiple banners for the popup.
- Each banner supports a title, rich text content (WYSIWYG), an optional image, status, and display order.
- Banners are language-specific.
- If active banners exist for the current language, they are displayed as an interactive slider within the popup (with next/previous arrows and dot navigation if more than one banner).
- A dedicated backend interface is provided for managing these banners under Addons -> Homepage Popup.

Development & Structure:
- Adheres to CS-Cart addon development standards and structure (addon.xml, init.php, func.php, schemas, controllers, templates, CSS, JS).
- All user-facing text is managed via language variables (English and Russian translations included).
- Settings are defined in `schemas/settings/schema.php`.
- A new database table `cscart_homepage_popup_banners` is added to store banner data.
- The codebase has been refactored based on CS-Cart best practices and comparison with default addons like 'banners'.