### PR TITLE
fix(smarty): Correct Smarty syntax error in banner update template

### DIFF
--- a/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/update.tpl
+++ b/design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/update.tpl
@@ -53,4 +53,9 @@
         {/capture}
     </form>
 {/capture}
-{include file="common/mainbox.tpl" title=($banner_data.banner_id ? $banner_data.title : __("homepage_popup.add_banner_button")) content=$smarty.capture.mainbox buttons=$smarty.capture.buttons_block}
+{if $banner_data.banner_id}
+    {assign var="mainbox_title_text" value=$banner_data.title}
+{else}
+    {assign var="mainbox_title_text" value=__("homepage_popup.add_banner_button")}
+{/if}
+{include file="common/mainbox.tpl" title=$mainbox_title_text content=$smarty.capture.mainbox buttons=$smarty.capture.buttons_block}


### PR DESCRIPTION
I resolved a Smarty syntax error in `design/backend/templates/addons/homepage_popup/views/homepage_popup_banners/update.tpl`. The error "Unexpected ?" was caused by using a ternary operator directly within the `title` attribute of an `{include file="common/mainbox.tpl" ...}` statement.

The fix involves:
- Refactoring the template to use an `{if...}{else...}{/if}` block to conditionally assign the mainbox title to a Smarty variable (`$mainbox_title_text`) before the `{include}` call.
- Passing this pre-assigned variable to the `title` attribute of the mainbox.

This change ensures valid Smarty syntax and improves template readability. I reviewed other backend templates and found no similar issues.